### PR TITLE
Rnf58

### DIFF
--- a/src/test/java/com/cosmeticos/controller/ProfessionalControllerTests.java
+++ b/src/test/java/com/cosmeticos/controller/ProfessionalControllerTests.java
@@ -13,6 +13,7 @@ import com.cosmeticos.repository.ProfessionalRepository;
 import com.cosmeticos.repository.UserRepository;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -948,6 +949,61 @@ public class ProfessionalControllerTests {
 						ProfessionalResponseBody.class);
 
 		Assert.assertEquals(HttpStatus.OK, getExchangeGet.getStatusCode());
+	}
+
+	//NAO TEM COMO EFETUAR O TESTE ABAIXO PARA O CARD RNF58 - MOTIVOS ABAIXO:
+	//Em ProfessionalController.Create não é permitido adicionar um Professional sem um professionalServices.
+	//Tem uma validação lá neste controller.
+	//Com isso, nunca vou conseguir fazer o teste, pois não tem como criar um Professional sem professionalServices
+	//para, somente depois, fazer o Update inserindo um professionalServices.
+	@Ignore
+	@Test
+	public void testUpdateProfessionalServicesToProfessionalWithoutProfessionalServices() throws URISyntaxException {
+		String email = "professionalServicesRNF58@email.com";
+
+		//CRIAMOS O JSON PARA CRIAR O PROFESSIONAL SEM PROFESSIONALSERVICES
+		String json = "{\n" +
+				"  \"professional\": {\n" +
+				"    \"address\": null,\n" +
+				"    \"birthDate\": 1120705200000,\n" +
+				"    \"cellPhone\": null,\n" +
+				"    \"dateRegister\": null,\n" +
+				"    \"genre\": null,\n" +
+				"    \"status\": null,\n" +
+				"    \"user\": {\n" +
+				"      \"email\": \""+ email +"\",\n" +
+				//"      \"idLogin\": null,\n" +
+				"      \"password\": \"123\",\n" +
+				"      \"sourceApp\": null,\n" +
+				"      \"username\": \""+ email +"\"\n" +
+				"    },\n" +
+				"    \"cnpj\": \"05404276846\",\n" +
+				//"    \"idProfessional\": null,\n" +
+				"    \"location\": 506592589,\n" +
+				"    \"nameProfessional\": \"professionalServicesRNF58\",\n" +
+				"    \"professionalServicesCollection\": null \n" +
+				"  }\n" +
+				"}";
+
+		System.out.println(json);
+
+
+		RequestEntity<String> entity =  RequestEntity
+				.post(new URI("/professionals"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.body(json);
+
+		ResponseEntity<ProfessionalResponseBody> exchange = restTemplate
+				.exchange(entity, ProfessionalResponseBody.class);
+
+		Assert.assertNotNull(exchange);
+		Assert.assertEquals(HttpStatus.OK, exchange.getStatusCode());
+
+		Professional professional = exchange.getBody().getProfessionalList().get(0);
+
+		Assert.assertEquals("professionalServicesRNF58", professional.getNameProfessional());
+		Assert.assertEquals(email, professional.getUser().getEmail());
 	}
 
 }


### PR DESCRIPTION
Alteração/Inclusão de Serviço a um profissional já existente não funciona

---

Em ProfessionalController.Create não é permitido adicionar um Professional sem um professionalServices. Tem uma validação lá neste controller.

Com isso, nunca vou conseguir fazer o teste, pois não tem como criar um Professional sem professionalServices para, somente depois, fazer o Update inserindo um professionalServices.

---

Conversei com o @garrydias1 e ele informou para fechar o card.

Mas enviei o Início do Teste efetuado para o GitHub assim mesmo, onde encontrei o uma validação que impede a execução do teste. Mas marquei o teste com @Ignore.