### PR TITLE
Rnf181 - Inativar o Customer e Professional quando o status de User tbm for inativo

### DIFF
--- a/src/main/java/com/cosmeticos/model/User.java
+++ b/src/main/java/com/cosmeticos/model/User.java
@@ -34,7 +34,7 @@ public class User implements Serializable {
         v.setUser(this);
     }
 
-    public  enum Status {
+    public enum Status {
 
         ACTIVE, INACTIVE, GONE, PENDING_PAYMENT
 
@@ -43,6 +43,12 @@ public class User implements Serializable {
     public enum PersonType{
 
         FISICA, JURIDICA
+
+    }
+
+    public enum UserType{
+
+        customer, professional
 
     }
 


### PR DESCRIPTION
CARD: https://trello.com/c/3GvNsb37/181-inativar-o-customer-e-professional-quando-o-status-de-user-tbm-for-inativo

BRANCH: Rnf181

DESCRIÇÃO: 
User.java: 
    - Adicionei o enum UserType; 

UserService.java: 
    - Adicionei CustomerService e ProfessionalService como @Autowired; 
    - Em update(), ao verificar o Status, adicionei uma validação se o Status é Inactive para chamar o método inactiveUserType(User); 
    - Em inactiveUserType() verifico o personType e faço uma chamada para customerService ou professionalService para fazer o update();